### PR TITLE
sc2: remove virtio-prng

### DIFF
--- a/tasks/kata.py
+++ b/tasks/kata.py
@@ -44,7 +44,7 @@ def build(ctx, nocache=False, push=False):
 
 
 @task
-def cli(ctx, mount_path=None):
+def cli(ctx, mount_path=join(PROJ_ROOT, "..", "kata-containers")):
     """
     Get a working environemnt to develop Kata
     """

--- a/tasks/sc2.py
+++ b/tasks/sc2.py
@@ -117,9 +117,6 @@ def install_sc2_runtime(debug=False):
         sc2=True,
     )
 
-
-@task  # DELETE ME
-def foo(ctx):  # DELETE ME
     # Replace the kata shim
     replace_kata_shim(
         dst_shim_binary=join(KATA_ROOT, "bin", "containerd-shim-kata-sc2-v2"),

--- a/tasks/sc2.py
+++ b/tasks/sc2.py
@@ -25,7 +25,10 @@ from tasks.util.env import (
     SC2_RUNTIMES,
     print_dotted_line,
 )
-from tasks.util.kata import replace_agent as replace_kata_agent
+from tasks.util.kata import (
+    replace_agent as replace_kata_agent,
+    replace_shim as replace_kata_shim,
+)
 from tasks.util.kubeadm import run_kubectl_command
 from tasks.util.toml import update_toml
 from tasks.util.versions import COCO_VERSION, KATA_VERSION
@@ -111,6 +114,15 @@ def install_sc2_runtime(debug=False):
             KATA_IMG_DIR, "kata-containers-initrd-confidential-sc2.img"
         ),
         debug=False,
+        sc2=True,
+    )
+
+
+@task  # DELETE ME
+def foo(ctx):  # DELETE ME
+    # Replace the kata shim
+    replace_kata_shim(
+        dst_shim_binary=join(KATA_ROOT, "bin", "containerd-shim-kata-sc2-v2"),
         sc2=True,
     )
 

--- a/tasks/util/kata.py
+++ b/tasks/util/kata.py
@@ -225,8 +225,7 @@ def replace_agent(
 
 def replace_shim(
     dst_shim_binary=join(KATA_ROOT, "bin", "containerd-shim-kata-sc2-v2"),
-    revert=False,
-    sc2=False,
+    sc2=True,
 ):
     """
     Replace the containerd-kata-shim with a custom one


### PR DESCRIPTION
In this PR we patch the Kata Runtime for SC2 to drop the `virtio-rng` device as suggested by Tobin here:
https://www.youtube.com/watch?v=ldix8Ak0Igw

As a food for thought, Kata updates are now completely transparent to this repo. We should consider keeping track of the branches, without using submodules, to flag an error in case we forget to re-build the Kata image...

Closes #102 