### PR TITLE
nydus: support host-sharing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,6 +171,68 @@ jobs:
           sleep 5
           echo "Knative test succesful!"
 
+      - name: "Run nydus host-share test"
+        run: |
+          # Change the snapshotter mode
+          ./bin/inv_wrapper.sh nydus-snapshotter.set-mode host-share
+
+          export SC2_RUNTIME_CLASS=qemu-${{ matrix.tee }}-sc2
+          export POD_LABEL="apps.sc2.io/name=helloworld-py"
+
+          # ----- Python Test ----
+
+          echo "Running python test..."
+          envsubst < ./demo-apps/helloworld-py-nydus/deployment.yaml | ./bin/kubectl apply -f -
+
+          # Wait for pod to be ready
+          until [ "$(./bin/kubectl get pods -l ${POD_LABEL} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" = "True" ]; do echo "Waiting for pod to be ready..."; sleep 2; done
+          sleep 1
+
+          # Get the pod's IP
+          service_ip=$(./bin/kubectl get services -o jsonpath='{.items[?(@.metadata.name=="coco-helloworld-py-node-port")].spec.clusterIP}')
+          [ "$(curl --retry 3 -X GET ${service_ip}:8080)" = "Hello World!" ]
+          envsubst < ./demo-apps/helloworld-py-nydus/deployment.yaml | ./bin/kubectl delete -f -
+
+          # Wait for pod to be deleted
+          ./bin/kubectl wait --for=delete -l ${POD_LABEL} pod --timeout=30s
+
+          # Extra cautionary sleep
+          sleep 5
+          echo "Python test succesful!"
+
+          # ----- Knative Test ----
+          envsubst < ./demo-apps/helloworld-knative-nydus/service.yaml | ./bin/kubectl apply -f -
+          sleep 1
+
+          # Get the service URL
+          service_url=$(./bin/kubectl get ksvc helloworld-knative  --output=custom-columns=URL:.status.url --no-headers)
+          [ "$(curl --retry 3 ${service_url})" = "Hello World!" ]
+
+          # Wait for pod to be deleted
+          envsubst < ./demo-apps/helloworld-knative-nydus/service.yaml | ./bin/kubectl delete -f -
+          ./bin/kubectl wait --for=delete -l ${POD_LABEL} pod --timeout=60s
+
+          # Extra cautionary sleep
+          sleep 5
+          echo "Knative test succesful!"
+
+          # Change the snapshotter mode back again
+          ./bin/inv_wrapper.sh nydus-snapshotter.set-mode guest-pull
+
+      - name: "Enable default-memory annotation"
+        run: |
+          for runtime_class in ${{ matrix.runtime_classes }}; do
+            ./bin/inv_wrapper.sh kata.enable-annotation default_memory --runtime ${runtime_class}
+            # Here we benefit that the last variable is the one we want to use
+            # for vm-cache
+            export SC2_RUNTIME_CLASS=${runtime_class}
+          done
+
+          # Aftre changing the annotation of the qemu-snp-sc2 runtime class we
+          # need to restart the VM cache
+          sudo -E ./vm-cache/target/release/vm-cache stop
+          sudo -E ./vm-cache/target/release/vm-cache background
+
       - name: "Enable default-memory annotation"
         run: |
           for runtime_class in ${{ matrix.runtime_classes }}; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,7 +251,6 @@ jobs:
 
       - name: "Run knative chaining demo"
         run: |
-          # TODO: may have to fetch content if we want to run in guest pull
           for runtime_class in ${{ matrix.runtime_classes }}; do
             echo "Running test for ${runtime_class}..."
             export SC2_RUNTIME_CLASS=${runtime_class}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -226,9 +226,10 @@ jobs:
           echo "Knative test succesful!"
 
           # Change the snapshotter mode back again (and purge)
-          ./bin/inv_wrapper.sh nydus-snapshotter.set-mode guest-pull
-          sleep 2
-          ./bin/inv_wrapper.sh nydus-snapshotter.purge
+          #
+          # ./bin/inv_wrapper.sh nydus-snapshotter.set-mode guest-pull
+          # sleep 2
+          # ./bin/inv_wrapper.sh nydus-snapshotter.purge
 
       - name: "Enable default-memory annotation"
         run: |
@@ -245,6 +246,7 @@ jobs:
 
       - name: "Run knative chaining demo"
         run: |
+          # TODO: may have to fetch content if we want to run in guest pull
           for runtime_class in ${{ matrix.runtime_classes }}; do
             echo "Running test for ${runtime_class}..."
             export SC2_RUNTIME_CLASS=${runtime_class}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,6 +176,7 @@ jobs:
           # Change the snapshotter mode and purge (necessary to clear
           # containred's content store)
           ./bin/inv_wrapper.sh nydus-snapshotter.set-mode host-share
+          sleep 2
           ./bin/inv_wrapper.sh nydus-snapshotter.purge
 
           export SC2_RUNTIME_CLASS=qemu-${{ matrix.tee }}-sc2
@@ -220,6 +221,7 @@ jobs:
 
           # Change the snapshotter mode back again (and purge)
           ./bin/inv_wrapper.sh nydus-snapshotter.set-mode guest-pull
+          sleep 2
           ./bin/inv_wrapper.sh nydus-snapshotter.purge
 
       - name: "Enable default-memory annotation"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,8 +173,10 @@ jobs:
 
       - name: "Run nydus host-share test"
         run: |
-          # Change the snapshotter mode
+          # Change the snapshotter mode and purge (necessary to clear
+          # containred's content store)
           ./bin/inv_wrapper.sh nydus-snapshotter.set-mode host-share
+          ./bin/inv_wrapper.sh nydus-snapshotter.purge
 
           export SC2_RUNTIME_CLASS=qemu-${{ matrix.tee }}-sc2
           export POD_LABEL="apps.sc2.io/name=helloworld-py"
@@ -216,8 +218,9 @@ jobs:
           sleep 5
           echo "Knative test succesful!"
 
-          # Change the snapshotter mode back again
+          # Change the snapshotter mode back again (and purge)
           ./bin/inv_wrapper.sh nydus-snapshotter.set-mode guest-pull
+          ./bin/inv_wrapper.sh nydus-snapshotter.purge
 
       - name: "Enable default-memory annotation"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,12 +179,12 @@ jobs:
           sleep 2
           ./bin/inv_wrapper.sh nydus-snapshotter.purge
 
+          export SC2_RUNTIME_CLASS=qemu-${{ matrix.tee }}-sc2
+          export POD_LABEL="apps.sc2.io/name=helloworld-py"
+
           # When updating the runtime we update all the config files, so we
           # need to re-start the cache
           sudo -E ./vm-cache/target/release/vm-cache restart
-
-          export SC2_RUNTIME_CLASS=qemu-${{ matrix.tee }}-sc2
-          export POD_LABEL="apps.sc2.io/name=helloworld-py"
 
           # ----- Python Test ----
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
           docker pull ghcr.io/sc2-sys/nydus-snapshotter:$(grep -oP 'NYDUS_SNAPSHOTTER_VERSION\s*=\s*"\K[^"]+' ./tasks/util/versions.py)
 
       - name: "Install SC2"
-        run: ./bin/inv_wrapper.sh sc2.deploy --clean --debug
+        run: ./bin/inv_wrapper.sh sc2.deploy --clean
 
       - name: "Run python hello world (cold and warm starts)"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,7 +210,7 @@ jobs:
           echo "Python test succesful!"
 
           # ----- Knative Test ----
-          envsubst < ./demo-apps/helloworld-knative-nydus/service.yaml | ./bin/kubectl apply -f -
+          envsubst < ./demo-apps/helloworld-knative/service.yaml | ./bin/kubectl apply -f -
           sleep 1
 
           # Get the service URL
@@ -218,7 +218,7 @@ jobs:
           [ "$(curl --retry 3 ${service_url})" = "Hello World!" ]
 
           # Wait for pod to be deleted
-          envsubst < ./demo-apps/helloworld-knative-nydus/service.yaml | ./bin/kubectl delete -f -
+          envsubst < ./demo-apps/helloworld-knative/service.yaml | ./bin/kubectl delete -f -
           ./bin/kubectl wait --for=delete -l ${POD_LABEL} pod --timeout=60s
 
           # Extra cautionary sleep

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,7 +189,7 @@ jobs:
           # ----- Python Test ----
 
           echo "Running python test..."
-          envsubst < ./demo-apps/helloworld-py-nydus/deployment.yaml | ./bin/kubectl apply -f -
+          envsubst < ./demo-apps/helloworld-py/deployment.yaml | ./bin/kubectl apply -f -
 
           # Wait for pod to be ready
           until [ "$(./bin/kubectl get pods -l ${POD_LABEL} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" = "True" ]; do echo "Waiting for pod to be ready..."; sleep 2; done
@@ -198,7 +198,7 @@ jobs:
           # Get the pod's IP
           service_ip=$(./bin/kubectl get services -o jsonpath='{.items[?(@.metadata.name=="coco-helloworld-py-node-port")].spec.clusterIP}')
           [ "$(curl --retry 3 -X GET ${service_ip}:8080)" = "Hello World!" ]
-          envsubst < ./demo-apps/helloworld-py-nydus/deployment.yaml | ./bin/kubectl delete -f -
+          envsubst < ./demo-apps/helloworld-py/deployment.yaml | ./bin/kubectl delete -f -
 
           # Wait for pod to be deleted
           ./bin/kubectl wait --for=delete -l ${POD_LABEL} pod --timeout=30s

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
           docker pull ghcr.io/sc2-sys/nydus-snapshotter:$(grep -oP 'NYDUS_SNAPSHOTTER_VERSION\s*=\s*"\K[^"]+' ./tasks/util/versions.py)
 
       - name: "Install SC2"
-        run: ./bin/inv_wrapper.sh sc2.deploy --clean
+        run: ./bin/inv_wrapper.sh sc2.deploy --clean --debug
 
       - name: "Run python hello world (cold and warm starts)"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,7 +177,9 @@ jobs:
           # containred's content store)
           ./bin/inv_wrapper.sh nydus-snapshotter.set-mode host-share
           sleep 2
+
           ./bin/inv_wrapper.sh nydus-snapshotter.purge
+          sleep 2
 
           export SC2_RUNTIME_CLASS=qemu-${{ matrix.tee }}-sc2
           export POD_LABEL="apps.sc2.io/name=helloworld-py"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,6 +172,8 @@ jobs:
           echo "Knative test succesful!"
 
       - name: "Run nydus host-share test"
+        # Host-share mechanisms seem not to work with TDX
+        if: ${{ matrix.tee != 'tdx' }}
         run: |
           # Change the snapshotter mode and purge (necessary to clear
           # containred's content store)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,7 +245,9 @@ jobs:
           sudo -E ./vm-cache/target/release/vm-cache restart
 
       - name: "Fetch content (see #130)"
-        run: sudo ctr -n k8s.io content fetch -k sc2cr.io/system/knative-sidecar@sha256:79d5f6031f308cee209c4c32eeab9113b29a1ed4096c5d657504096734ca3b1d
+        run: |
+          sudo ctr -n k8s.io content fetch -k sc2cr.io/system/knative-sidecar@sha256:79d5f6031f308cee209c4c32eeab9113b29a1ed4096c5d657504096734ca3b1d
+          sudo ctr -n k8s.io content fetch registry.k8s.io/pause:3.8
 
       - name: "Run knative chaining demo"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,22 +230,7 @@ jobs:
 
           # Aftre changing the annotation of the qemu-snp-sc2 runtime class we
           # need to restart the VM cache
-          sudo -E ./vm-cache/target/release/vm-cache stop
-          sudo -E ./vm-cache/target/release/vm-cache background
-
-      - name: "Enable default-memory annotation"
-        run: |
-          for runtime_class in ${{ matrix.runtime_classes }}; do
-            ./bin/inv_wrapper.sh kata.enable-annotation default_memory --runtime ${runtime_class}
-            # Here we benefit that the last variable is the one we want to use
-            # for vm-cache
-            export SC2_RUNTIME_CLASS=${runtime_class}
-          done
-
-          # Aftre changing the annotation of the qemu-snp-sc2 runtime class we
-          # need to restart the VM cache
-          sudo -E ./vm-cache/target/release/vm-cache stop
-          sudo -E ./vm-cache/target/release/vm-cache background
+          sudo -E ./vm-cache/target/release/vm-cache restart
 
       - name: "Run knative chaining demo"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -227,9 +227,9 @@ jobs:
 
           # Change the snapshotter mode back again (and purge)
           #
-          # ./bin/inv_wrapper.sh nydus-snapshotter.set-mode guest-pull
-          # sleep 2
-          # ./bin/inv_wrapper.sh nydus-snapshotter.purge
+          ./bin/inv_wrapper.sh nydus-snapshotter.set-mode guest-pull
+          sleep 2
+          ./bin/inv_wrapper.sh nydus-snapshotter.purge
 
       - name: "Enable default-memory annotation"
         run: |
@@ -243,6 +243,9 @@ jobs:
           # Aftre changing the annotation of the qemu-snp-sc2 runtime class we
           # need to restart the VM cache
           sudo -E ./vm-cache/target/release/vm-cache restart
+
+      - name: "Fetch content (see #130)"
+        run: sudo ctr -n k8s.io content fetch -k sc2cr.io/system/knative-sidecar@sha256:79d5f6031f308cee209c4c32eeab9113b29a1ed4096c5d657504096734ca3b1d
 
       - name: "Run knative chaining demo"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,9 +177,11 @@ jobs:
           # containred's content store)
           ./bin/inv_wrapper.sh nydus-snapshotter.set-mode host-share
           sleep 2
-
           ./bin/inv_wrapper.sh nydus-snapshotter.purge
-          sleep 2
+
+          # When updating the runtime we update all the config files, so we
+          # need to re-start the cache
+          sudo -E ./vm-cache/target/release/vm-cache restart
 
           export SC2_RUNTIME_CLASS=qemu-${{ matrix.tee }}-sc2
           export POD_LABEL="apps.sc2.io/name=helloworld-py"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Installed binaries
+bbolt
 cosign
 crictl
 kubeadm

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ For further documentation, you may want to check these other documents:
 * [CoCo Upgrade](./docs/upgrade_coco.md) - upgrade the current CoCo version.
 * [Guest Components](./docs/guest_components.md) - instructions to patch components inside SC2 guests.
 * [Host Kernel](./docs/host_kernel.md) - bump the kernel version in the host.
+* [Image Pull](./docs/image_pull.md) - details on the image-pulling mechanisms supported in SC2.
 * [K8s](./docs/k8s.md) - documentation about configuring a single-node Kubernetes cluster.
 * [Kata](./docs/kata.md) - instructions to build our custom Kata fork and `initrd` images.
 * [Key Broker Service](./docs/kbs.md) - docs on using and patching the KBS.

--- a/docs/image_pull.md
+++ b/docs/image_pull.md
@@ -16,6 +16,9 @@ the cVM.
 Albeit secure, this mechanism has high performance overheads as the image must
 be pulled every single time, precluding any caching benefits.
 
+To mitigate the performance overheads, we can convert the OCI image to a
+Nydus image, that supports lazy loading of container data.
+
 ### Host Share
 
 The host share mechanism mounts a container image from the host to the guest.
@@ -26,3 +29,23 @@ attestation.
 
 We could mount encrypted images from the host to the guest, but we would be
 losing on the de-duplication opportunities in the host.
+
+### Usage
+
+Each image pull mechanism is implemented as a different remote snapshotter
+in containerd, all of them based on the [nydus-snapshotter](
+https://github.com/containerd/nydus-snapshotter/) plus our modifications.
+
+To switch between different image-pulling mechanisms, you only need to change
+the snapshotter mode:
+
+```bash
+inv nydus-snapshotter.set-mode [guest-pull,host-share]
+```
+
+If you see any snapshotter related issues (either in the `containerd` or the
+`nydus-snapshotter` journal logs), you can purge the snapshotters:
+
+```bash
+inv nydus-snapshotter.purge
+```

--- a/docs/image_pull.md
+++ b/docs/image_pull.md
@@ -1,0 +1,28 @@
+## Image Pull
+
+This document describes the different mechanisms to get a container image
+inside a cVM in SC2. We _always_ assume that the integrity of container images
+must be validated. We also consider the situation in which their confidentiality
+must also be preserved.
+
+### Guest Pull
+
+The guest pull mechanism always pulls the container image inside the guest cVM.
+This is the default mechanism in CoCo as it allows the most secure, and simplest
+deployment: users sign (and encrypt) container images locally, they upload
+them to a container registry, pull them inside the cVM, and decrypt them inside
+the cVM.
+
+Albeit secure, this mechanism has high performance overheads as the image must
+be pulled every single time, precluding any caching benefits.
+
+### Host Share
+
+The host share mechanism mounts a container image from the host to the guest.
+Given that the host is untrusted, this mechanism only works for images that
+do not have confidentiality requirements. To maintain integrity, we mount
+the image with `dm-verity`, and validate the `dm-verity` device as part of
+attestation.
+
+We could mount encrypted images from the host to the guest, but we would be
+losing on the de-duplication opportunities in the host.

--- a/docs/image_pull.md
+++ b/docs/image_pull.md
@@ -27,6 +27,9 @@ do not have confidentiality requirements. To maintain integrity, we mount
 the image with `dm-verity`, and validate the `dm-verity` device as part of
 attestation.
 
+We choose to mount individual layers separately (rather than whole images),
+but we should measure that the former is actually better than the latter.
+
 We could mount encrypted images from the host to the guest, but we would be
 losing on the de-duplication opportunities in the host.
 

--- a/tasks/containerd.py
+++ b/tasks/containerd.py
@@ -72,20 +72,10 @@ def cli(ctx, mount_path=join(PROJ_ROOT, "..", "containerd")):
     run("docker exec -it {} bash".format(CONTAINERD_CTR_NAME), shell=True, check=True)
 
 
-@task
-def set_log_level(ctx, log_level):
+def set_log_level(log_level):
     """
     Set containerd's log level, must be one in: info, debug
     """
-    allowed_log_levels = ["info", "debug"]
-    if log_level not in allowed_log_levels:
-        print(
-            "Unsupported log level '{}'. Must be one in: {}".format(
-                log_level, allowed_log_levels
-            )
-        )
-        return
-
     updated_toml_str = """
     [debug]
     level = "{log_level}"

--- a/tasks/containerd.py
+++ b/tasks/containerd.py
@@ -72,6 +72,20 @@ def cli(ctx, mount_path=join(PROJ_ROOT, "..", "containerd")):
     run("docker exec -it {} bash".format(CONTAINERD_CTR_NAME), shell=True, check=True)
 
 
+@task
+def stop(ctx):
+    """
+    Stop the containerd work-on container
+    """
+    result = run(
+        "docker rm -f {}".format(CONTAINERD_CTR_NAME),
+        shell=True,
+        check=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
 def set_log_level(log_level):
     """
     Set containerd's log level, must be one in: info, debug

--- a/tasks/containerd.py
+++ b/tasks/containerd.py
@@ -182,6 +182,10 @@ def install_bbolt(debug=False, clean=False):
     print_dotted_line("Installing bbolt")
 
     tmp_ctr_name = "bbolt_install"
+    if is_ctr_running(tmp_ctr_name):
+        result = run(f"docker rm -f {tmp_ctr_name}", shell=True, capture_output=True)
+        assert result.returncode == 0
+
     result = run(
         f"docker run -d -it --name {tmp_ctr_name} golang:{GO_VERSION} bash",
         shell=True,
@@ -216,5 +220,7 @@ def install_bbolt(debug=False, clean=False):
         raise RuntimeError("Error cp-ing from container")
     if debug:
         print(result.stdout.decode("utf-8").strip())
+
+    rm_container()
 
     print("Success!")

--- a/tasks/containerd.py
+++ b/tasks/containerd.py
@@ -31,23 +31,24 @@ CONTAINERD_CTR_BINPATH = "/go/src/github.com/sc2-sys/containerd/bin"
 CONTAINERD_HOST_BINPATH = "/usr/bin"
 
 
-def do_build(debug=False):
-    docker_cmd = "docker build -t {} -f {} .".format(
+def do_build(nocache=False):
+    docker_cmd = "docker build{} -t {} -f {} .".format(
+        " --no-cache" if nocache else "",
         CONTAINERD_IMAGE_TAG,
         join(PROJ_ROOT, "docker", "containerd.dockerfile"),
     )
-    result = run(docker_cmd, shell=True, capture_output=True, cwd=PROJ_ROOT)
-    assert result.returncode == 0, print(result.stderr.decode("utf-8").strip())
-    if debug:
-        print(result.stdout.decode("utf-8").strip())
+    run(docker_cmd, shell=True, check=True, cwd=PROJ_ROOT)
 
 
 @task
-def build(ctx):
+def build(ctx, nocache=False, push=False):
     """
     Build the containerd fork for CoCo
     """
-    do_build(debug=True)
+    do_build(nocache=nocache)
+
+    if push:
+        run(f"docker push {CONTAINERD_IMAGE_TAG}", shell=True, check=True)
 
 
 @task

--- a/tasks/containerd.py
+++ b/tasks/containerd.py
@@ -216,3 +216,5 @@ def install_bbolt(debug=False, clean=False):
         raise RuntimeError("Error cp-ing from container")
     if debug:
         print(result.stdout.decode("utf-8").strip())
+
+    print("Success!")

--- a/tasks/kata.py
+++ b/tasks/kata.py
@@ -67,20 +67,10 @@ def stop(ctx):
     stop_kata_workon_ctr()
 
 
-@task
-def set_log_level(ctx, log_level):
+def set_log_level(log_level):
     """
     Set kata's log level, must be one in: info, debug
     """
-    allowed_log_levels = ["info", "debug"]
-    if log_level not in allowed_log_levels:
-        print(
-            "Unsupported log level '{}'. Must be one in: {}".format(
-                log_level, allowed_log_levels
-            )
-        )
-        return
-
     enable_debug = str(log_level == "debug").lower()
 
     for runtime in KATA_RUNTIMES + SC2_RUNTIMES:
@@ -146,6 +136,7 @@ def hot_replace_shim(ctx, runtime="qemu-snp-sc2"):
             ),
         ),
         sc2=runtime in SC2_RUNTIMES,
+        hot_replace=True,
     )
 
     restart_containerd()

--- a/tasks/kernel.py
+++ b/tasks/kernel.py
@@ -54,8 +54,10 @@ def build_guest(debug=False, hot_replace=False):
             ctr_path, host_path, sudo=False, debug=debug, hot_replace=hot_replace
         )
 
+    # The -V option enables dm-verity support in the guest (technically only
+    # needed for SC2)
     build_kernel_base_cmd = [
-        f"./build-kernel.sh -x -f -v {GUEST_KERNEL_VERSION}",
+        f"./build-kernel.sh -x -V -f -v {GUEST_KERNEL_VERSION}",
         "-u 'https://cdn.kernel.org/pub/linux/kernel/v{}.x/'".format(
             GUEST_KERNEL_VERSION.split(".")[0]
         ),
@@ -117,4 +119,7 @@ def build_guest(debug=False, hot_replace=False):
 
 @task
 def hot_replace_guest(ctx, debug=False):
+    """
+    Hot-replace guest kernel
+    """
     build_guest(debug=debug, hot_replace=True)

--- a/tasks/nydus.py
+++ b/tasks/nydus.py
@@ -2,7 +2,7 @@ from invoke import task
 from os.path import join
 from subprocess import run
 from tasks.util.docker import copy_from_ctr_image
-from tasks.util.env import GHCR_URL, GITHUB_ORG, PROJ_ROOT, print_dotted_line
+from tasks.util.env import COCO_ROOT, GHCR_URL, GITHUB_ORG, PROJ_ROOT, print_dotted_line
 from tasks.util.nydus import NYDUSIFY_PATH
 from tasks.util.versions import NYDUS_VERSION
 
@@ -27,11 +27,19 @@ def build(ctx, nocache=False, push=False):
 
 
 def do_install():
-    print_dotted_line(f"Installing nydusify (v{NYDUS_VERSION})")
+    print_dotted_line(f"Installing nydus image services (v{NYDUS_VERSION})")
 
+    # Non root-owned binaries
     ctr_bin = ["/go/src/github.com/sc2-sys/nydus/contrib/nydusify/cmd/nydusify"]
     host_bin = [NYDUSIFY_PATH]
     copy_from_ctr_image(NYDUS_IMAGE_TAG, ctr_bin, host_bin, requires_sudo=False)
+
+    # Root-owned binaries
+    # The host-pull functionality requires nydus-image >= 2.3.0, but the one
+    # installed with the daemon is 2.2.4
+    ctr_bin = ["/go/src/github.com/sc2-sys/nydus/target/release/nydus-image"]
+    host_bin = [join(COCO_ROOT, "bin", "nydus-image")]
+    copy_from_ctr_image(NYDUS_IMAGE_TAG, ctr_bin, host_bin, requires_sudo=True)
 
     print("Success!")
 

--- a/tasks/nydus.py
+++ b/tasks/nydus.py
@@ -1,13 +1,16 @@
 from invoke import task
 from os.path import join
 from subprocess import run
-from tasks.util.docker import copy_from_ctr_image
+from tasks.util.docker import copy_from_ctr_image, is_ctr_running
 from tasks.util.env import COCO_ROOT, GHCR_URL, GITHUB_ORG, PROJ_ROOT, print_dotted_line
 from tasks.util.nydus import NYDUSIFY_PATH
 from tasks.util.versions import NYDUS_VERSION
 
 NYDUS_CTR_NAME = "nydus-workon"
 NYDUS_IMAGE_TAG = join(GHCR_URL, GITHUB_ORG, "nydus") + f":{NYDUS_VERSION}"
+
+NYDUS_IMAGE_CTR_PATH = "/go/src/github.com/sc2-sys/nydus/target/release/nydus-image"
+NYDUS_IMAGE_HOST_PATH = join(COCO_ROOT, "bin", "nydus-image")
 
 
 @task
@@ -37,8 +40,8 @@ def do_install():
     # Root-owned binaries
     # The host-pull functionality requires nydus-image >= 2.3.0, but the one
     # installed with the daemon is 2.2.4
-    ctr_bin = ["/go/src/github.com/sc2-sys/nydus/target/release/nydus-image"]
-    host_bin = [join(COCO_ROOT, "bin", "nydus-image")]
+    ctr_bin = [NYDUS_IMAGE_CTR_PATH]
+    host_bin = [NYDUS_IMAGE_HOST_PATH]
     copy_from_ctr_image(NYDUS_IMAGE_TAG, ctr_bin, host_bin, requires_sudo=True)
 
     print("Success!")
@@ -50,3 +53,61 @@ def install(ctx):
     Install the nydusify CLI tool
     """
     do_install()
+
+
+@task
+def cli(ctx, mount_path=join(PROJ_ROOT, "..", "nydus")):
+    """
+    Get a working environemnt for nydusd
+    """
+    if not is_ctr_running(NYDUS_CTR_NAME):
+        docker_cmd = [
+            "docker run",
+            "-d -it",
+            # The container path comes from the dockerfile in:
+            # ./docker/nydus.dockerfile
+            f"-v {mount_path}:/go/src/github.com/sc2-sys/nydus",
+            "--name {}".format(NYDUS_CTR_NAME),
+            NYDUS_IMAGE_TAG,
+            "bash",
+        ]
+        docker_cmd = " ".join(docker_cmd)
+        run(docker_cmd, shell=True, check=True, cwd=PROJ_ROOT)
+
+    run(
+        "docker exec -it {} bash".format(NYDUS_CTR_NAME),
+        shell=True,
+        check=True,
+    )
+
+
+@task
+def stop(ctx):
+    """
+    Remove the Kata developement environment
+    """
+    result = run(
+        "docker rm -f {}".format(NYDUS_CTR_NAME),
+        shell=True,
+        check=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+@task
+def hot_replace(ctx):
+    """
+    Replace nydus-image binary from running workon container
+    """
+    if not is_ctr_running(NYDUS_CTR_NAME):
+        print("Must have the work-on container running to hot replace!")
+        print("Consider running: inv nydus-snapshotter.cli ")
+
+    print("cp {NYDUS_CTR_NAME}:{NYDUS_IMAGE_CTR_PATH} {NYDUS_IMAGE_HOST_PATH}")
+    docker_cmd = (
+        f"sudo docker cp {NYDUS_CTR_NAME}:{NYDUS_IMAGE_CTR_PATH} "
+        f"{NYDUS_IMAGE_HOST_PATH}"
+    )
+    result = run(docker_cmd, shell=True, capture_output=True)
+    assert result.returncode == 0

--- a/tasks/nydus_snapshotter.py
+++ b/tasks/nydus_snapshotter.py
@@ -90,7 +90,16 @@ def wait_for_snapshot_metadata_to_be_gced(snapshotter, debug=False):
                 if debug:
                     print(f"WARNING: bucket {snapshotter} not found in metadata")
                     run(f"rm {tmp_db_path}", shell=True, check=True)
-                    return
+                return
+            else:
+                print(
+                    "ERROR: running bbolt command: stdout: {}, stderr: {}".format(
+                        stdout, result.stderr.decode("utf-8").strip()
+                    )
+                )
+                run(f"rm {tmp_db_path}", shell=True, check=True)
+
+                raise RuntimeError("Error running bbolt command!")
         elif result.returncode == 0:
             if len(stdout) == 0:
                 run(f"rm {tmp_db_path}", shell=True, check=True)

--- a/tasks/nydus_snapshotter.py
+++ b/tasks/nydus_snapshotter.py
@@ -205,16 +205,16 @@ def hot_replace(ctx):
 @task
 def set_mode(ctx, mode):
     """
-    Set the nydus-snapshotter operation mode: 'guest-pulling', or 'host-sharing'
+    Set the nydus-snapshotter operation mode: 'guest-pull', or 'host-share'
     """
-    if mode not in ["guest-pulling", "host-sharing"]:
+    if mode not in ["guest-pull", "host-share"]:
         print(f"ERROR: unrecognised nydus-snapshotter mode: {mode}")
-        print("ERROR: mode must be one in: ['guest-pulling', 'host-sharing']")
+        print("ERROR: mode must be one in: ['guest-pull', 'host-share']")
         return
 
     config_file = (
         NYDUS_SNAPSHOTTER_HOST_SHARING_CONFIG
-        if mode == "host-sharing"
+        if mode == "host-share"
         else NYDUS_SNAPSHOTTER_GUEST_PULL_CONFIG
     )
     exec_start = (

--- a/tasks/nydus_snapshotter.py
+++ b/tasks/nydus_snapshotter.py
@@ -182,6 +182,20 @@ def cli(ctx, mount_path=join(PROJ_ROOT, "..", "nydus-snapshotter")):
 
 
 @task
+def stop(ctx):
+    """
+    Stop the nydus-snapshotter work-on container
+    """
+    result = run(
+        "docker rm -f {}".format(NYDUS_SNAPSHOTTER_CTR_NAME),
+        shell=True,
+        check=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+@task
 def hot_replace(ctx):
     """
     Replace nydus-snapshotter binaries from running workon container

--- a/tasks/nydus_snapshotter.py
+++ b/tasks/nydus_snapshotter.py
@@ -88,7 +88,7 @@ def wait_for_snapshot_metadata_to_be_gced(snapshotter, debug=False):
             # at all, never
             if stdout == "bucket not found":
                 if debug:
-                    print("WARNING: bucket {snapsotter} not found in metadata")
+                    print(f"WARNING: bucket {snapshotter} not found in metadata")
                     run(f"rm {tmp_db_path}", shell=True, check=True)
                     return
         elif result.returncode == 0:

--- a/tasks/nydus_snapshotter.py
+++ b/tasks/nydus_snapshotter.py
@@ -218,8 +218,8 @@ def set_mode(ctx, mode):
         else NYDUS_SNAPSHOTTER_GUEST_PULL_CONFIG
     )
     exec_start = (
-        f"{NYDUS_SNAPSHOTTER_HOST_BINPATH}/containerd-nydus-grpc-hybrid "
-        f"--config ${config_file} --log-to-stdout"
+        f"{NYDUS_SNAPSHOTTER_HOST_BINPATH}/containerd-nydus-grpc "
+        f"--config {config_file} --log-to-stdout"
     )
 
     service_config = """

--- a/tasks/sc2.py
+++ b/tasks/sc2.py
@@ -2,16 +2,23 @@ from invoke import task
 from os import environ, makedirs
 from os.path import exists, join
 from subprocess import run
-from tasks.containerd import install as containerd_install
+from tasks.containerd import (
+    install as containerd_install,
+    set_log_level as containerd_set_log_level,
+)
 from tasks.demo_apps import (
     do_push_to_local_registry as push_demo_apps_to_local_registry,
 )
 from tasks.k8s import install as k8s_tooling_install
 from tasks.k9s import install as k9s_install
+from tasks.kata import set_log_level as kata_set_log_level
 from tasks.kernel import build_guest as build_guest_kernel
 from tasks.knative import install as knative_install
 from tasks.kubeadm import create as k8s_create, destroy as k8s_destroy
-from tasks.nydus_snapshotter import install as nydus_snapshotter_install
+from tasks.nydus_snapshotter import (
+    install as nydus_snapshotter_install,
+    set_log_level as nydus_snapshotter_set_log_level,
+)
 from tasks.nydus import do_install as nydus_install
 from tasks.operator import (
     install as operator_install,
@@ -353,3 +360,22 @@ def destroy(ctx, debug=False):
     assert result.returncode == 0, print(result.stderr.decode("utf-8").strip())
     if debug:
         print(result.stdout.decode("utf-8").strip())
+
+
+@task
+def set_log_level(ctx, log_level):
+    """
+    Set log level for all SC2 containers: containerd, kata, and nydus-snapshotter
+    """
+    allowed_log_levels = ["info", "debug"]
+    if log_level not in allowed_log_levels:
+        print(
+            "Unsupported log level '{}'. Must be one in: {}".format(
+                log_level, allowed_log_levels
+            )
+        )
+        return
+
+    containerd_set_log_level(log_level)
+    kata_set_log_level(log_level)
+    nydus_snapshotter_set_log_level(log_level)

--- a/tasks/sc2.py
+++ b/tasks/sc2.py
@@ -4,6 +4,7 @@ from os.path import exists, join
 from subprocess import run
 from tasks.containerd import (
     install as containerd_install,
+    install_bbolt as bbolt_install,
     set_log_level as containerd_set_log_level,
 )
 from tasks.demo_apps import (
@@ -259,6 +260,7 @@ def deploy(ctx, debug=False, clean=False):
 
     # Build and install containerd
     containerd_install(debug=debug, clean=clean)
+    bbolt_install(debug=debug, clean=clean)
 
     # Install k8s tooling (including k9s)
     k8s_tooling_install(debug=debug, clean=clean)

--- a/tools/check-fork-hashes/src/main.rs
+++ b/tools/check-fork-hashes/src/main.rs
@@ -110,6 +110,14 @@ fn main() {
             dict.insert("branches", "sc2-main");
             dict
         },
+        {
+            let mut dict = HashMap::new();
+            dict.insert("repo_name", "nydus-snapshotter");
+            dict.insert("version_str", "NYDUS_SNAPSHOTTER_VERSION");
+            dict.insert("ctr_src_paths", "/go/src/github.com/sc2-sys/nydus-snapshotter");
+            dict.insert("branches", "sc2-main");
+            dict
+        },
     ];
 
     let mut all_match = true;

--- a/tools/check-fork-hashes/src/main.rs
+++ b/tools/check-fork-hashes/src/main.rs
@@ -114,7 +114,10 @@ fn main() {
             let mut dict = HashMap::new();
             dict.insert("repo_name", "nydus-snapshotter");
             dict.insert("version_str", "NYDUS_SNAPSHOTTER_VERSION");
-            dict.insert("ctr_src_paths", "/go/src/github.com/sc2-sys/nydus-snapshotter");
+            dict.insert(
+                "ctr_src_paths",
+                "/go/src/github.com/sc2-sys/nydus-snapshotter",
+            );
             dict.insert("branches", "sc2-main");
             dict
         },


### PR DESCRIPTION
The main issue to support host-sharing is the co-existence of guest-pulling and host-sharing versions of the nydus snapshotter, as well as other non-nydus snapshotters.

Before starting a pod sandbox, containerd will check if the pause image is present on the machine. If it is not it will "pull it" with the help of the snapshotter. This "pull" is crucial as the nydus snapshotter will export the right Kata virtual colume to handle the pull: 
* For `guest-pull` it will generate a `GuestImagePull` virtual volume that will make the Kata Agent try to `pull_image` inside the guest (for the pause image this is just unpacking the bundle in the initrd).
* For `host-share` it will convert the OCI layers to `tarfs` layers, and generate virtual volumes that indicate the blobs to mount into the guest.

Consequently, if we _skip_ the "pull" that happens during `ensureImageExists`, we never generate this virtual volumes, and execution fails. In order to make sure we pull when we need to, containerd needs to keep a per-snapshotter map of what images it has already pulled. Here's the catch: `guest-pull` and `host-share` are _technically_ the same snapshotter. (This also applies for variations of the `host-share` mode: `image_block`, `layer_block` and each one with `_verity`.)

The solution we will adopt is to install host-sharing as a "different" snapshotter (which we implement here) together with a patch in containerd that keeps track of what images have been pulled on a per-snapshotter basis (not on a global basis).

On top of that, we need to do some work on Kata, but most of it is already here: https://github.com/kata-containers/kata-containers/pull/7837. The only notable additions are to manually start the udev daemon, as we are still using the Kata Agent as `/init`, and to check that the (host-)mounted dm-verity hashes actually correspond to the layer digests. The latter will wait until we re-introduce image signature validation and attestation, as we need to get the ground truth from somewhere.

Another issue we ran into while testing is that, if two layers have the same digest, the tarfs module in the nydus-snapshotter will sometimes trigger an error due to a race condition.

Once this PR is merged in, both snapshotters should be usable without having to restart the snapshotters by using:

```bash
inv nydus-snapshotter.set-mode [guest-pull|host-share]
```

the host-share mode uses `layer_block_with_verity`. With `guest-pull` mode, however, there is an open issue in the upstream repo regarding snapshotter restarts: https://github.com/containerd/nydus-snapshotter/issues/631. This means that, in general, when changing the snapshotter mode it is safer to purge all snapshots:

```bash
inv nydus-snapshotter.purge
```

Purging also proved tricky, as it is not enough to remove the contents of `/var/lib/containerd-nydus*`. `containerd` keeps track of snapshot metadata in its metadata DB in `/var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db`. We cannot easily delete elements from that DB, so after removing the snapshots manually, we wait for the GC to remove the elements from the DB.