### PR TITLE
coco: bump to v0.12.0

### DIFF
--- a/docs/upgrade_coco.md
+++ b/docs/upgrade_coco.md
@@ -21,42 +21,31 @@ to the version they point to.
 
 ### Upgrade CoCo Version Tag
 
-First, bump the `COCO_RELEASE_VERSION` in `tasks/util/env.py`. Then work-out
+First, bump the `COCO_VERSION` in `tasks/util/versions.py`. Then work-out
 what Kata version is being used, and `cd` into your `kata-containers` source
 tree.
 
 ### Update Kata and Guest Components
 
-The source tree should point to `sc2-main`. We need to rebase it on the latest
-Kata:
+First, rebase `guest-components` to the latest `main` (guest-components is
+not tagged anymore, afaict).
+
+Then rebase `sc2-main` and `sc2-baseline` to the new Kata tag (pinned by the
+CoCo release). You should also update the `KATA_VERSION` variable in the
+versions file.
+
+Once you have pushed the branches to the remote, you will have to re-build
+the Kata image:
 
 ```bash
-git fetch upstream
-
-# You may try to first rebase and re-build on a test branch
-git checkout -b sc2-main-test
-git rebase <TAG>
-git push origin sc2-main-test
-```
-
-If you have any changes on top of guest components, you should rebase them
-on top of `0.10.0`, re-build, and push the tag. Note that you Kata fork should
-point to a guest components version with the `sc2-main` branch.
-
-Now, if you have used a test branch, update the branch name in the kata
-dockerfile in `./docker/kata.dockerfile`, and try to re-build Kata:
-
-```bash
-inv kata.build
-inv kata.replace-agent
+inv kata.build --nocache --push
 ```
 
 ### Dry Run
 
-The only thing remaining is to test a fresh install:
+The easies way to test the deployment is to start a new cluster from scratch,
+and run some demo functions:
 
 ```bash
-inv kubeadm.create operator.install operator.install-cc-runtime knative.install
+inv sc2.destroy sc2.deploy --clean
 ```
-
-and run some demo functions.

--- a/tasks/sc2.py
+++ b/tasks/sc2.py
@@ -116,6 +116,10 @@ def install_sc2_runtime(debug=False):
         # FIXME: we need to update the default_memory to be able to run the
         # Knative chaining test. This will change when memory hot-plugging
         # is supported
+        # FIXME 2: we need to set the default max vcpus, as the kata-runtime,
+        # and containerd-shim seem to give it different default values. Not
+        # an issue as hot-plugging vCPUs is not supported so we can never
+        # exceed the default (1).
         updated_toml_str = """
         [factory]
         vm_cache_number = {vm_cache_number}
@@ -124,6 +128,7 @@ def install_sc2_runtime(debug=False):
         hot_plug_vfio = "root-port"
         pcie_root_port = 2
         default_memory = 6144
+        default_maxvcpus = 1
         """.format(
             vm_cache_number=VM_CACHE_SIZE
         )

--- a/tasks/util/kata.py
+++ b/tasks/util/kata.py
@@ -194,6 +194,7 @@ def replace_agent(
     script_files = [
         "initrd-builder/initrd_builder.sh",
         "rootfs-builder/rootfs.sh",
+        "rootfs-builder/nvidia/",
         "rootfs-builder/ubuntu/config.sh",
         "rootfs-builder/ubuntu/Dockerfile.in",
         "rootfs-builder/ubuntu/rootfs_lib.sh",

--- a/tasks/util/registry.py
+++ b/tasks/util/registry.py
@@ -160,7 +160,7 @@ def start(debug=False, clean=False):
     """.format(
         containerd_base_certs_dir=containerd_base_certs_dir
     )
-    update_toml(CONTAINERD_CONFIG_FILE, updated_toml_str)
+    update_toml(CONTAINERD_CONFIG_FILE, updated_toml_str, requires_root=True)
 
     # Add the correspnding configuration to containerd
     containerd_certs_dir = join(containerd_base_certs_dir, LOCAL_REGISTRY_URL)

--- a/tasks/util/versions.py
+++ b/tasks/util/versions.py
@@ -1,6 +1,6 @@
 # CoCo versions (note that the CoCo release pins the Kata Version)
-COCO_VERSION = "0.10.0"
-KATA_VERSION = "3.9.0"
+COCO_VERSION = "0.12.0"
+KATA_VERSION = "3.13.0"
 
 # Base software versions
 GO_VERSION = "1.23.0"

--- a/tools/check-fork-hashes/src/main.rs
+++ b/tools/check-fork-hashes/src/main.rs
@@ -104,14 +104,6 @@ fn main() {
         },
         {
             let mut dict = HashMap::new();
-            dict.insert("repo_name", "guest-components");
-            dict.insert("version_str", "COCO_VERSION");
-            dict.insert("ctr_src_paths", "/usr/src/guest-components");
-            dict.insert("branches", "sc2-main");
-            dict
-        },
-        {
-            let mut dict = HashMap::new();
             dict.insert("repo_name", "containerd");
             dict.insert("version_str", "CONTAINERD_VERSION");
             dict.insert("ctr_src_paths", "/go/src/github.com/sc2-sys/containerd");


### PR DESCRIPTION
The main thing to change is that now it seems that `/etc/containerd/config.toml` is root-owned after CoCo installation, so we need to read/update the TOML with care.

Closes #133 