### PR TITLE
tdx: move to using a disk image based on 24.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,9 +46,8 @@ jobs:
       matrix:
         include:
           - tee: snp
-            runtime_classes: "qemu qemu-coco-dev qemu-snp qemu-snp-sc2"
-          - tee: tdx
-            runtime_classes: "qemu qemu-coco-dev qemu-tdx qemu-tdx-sc2"
+            # Temporarily disable TDX tests, until server is available again
+            # - tee: tdx
 
     runs-on: [self-hosted, "${{ matrix.tee }}"]
     env:

--- a/tasks/kata.py
+++ b/tasks/kata.py
@@ -104,6 +104,9 @@ def hot_replace_agent(ctx, debug=False, runtime="qemu-snp-sc2"):
         dst_initrd_path=join(
             KATA_IMG_DIR, "kata-containers-initrd-confidential-sc2.img"
         ),
+        dst_img_path=join(
+            KATA_IMG_DIR, "kata-containers-confidential-sc2.img"
+        ),
         debug=debug,
         sc2=runtime in SC2_RUNTIMES,
         hot_replace=True,

--- a/tasks/kata.py
+++ b/tasks/kata.py
@@ -104,9 +104,7 @@ def hot_replace_agent(ctx, debug=False, runtime="qemu-snp-sc2"):
         dst_initrd_path=join(
             KATA_IMG_DIR, "kata-containers-initrd-confidential-sc2.img"
         ),
-        dst_img_path=join(
-            KATA_IMG_DIR, "kata-containers-confidential-sc2.img"
-        ),
+        dst_img_path=join(KATA_IMG_DIR, "kata-containers-confidential-sc2.img"),
         debug=debug,
         sc2=runtime in SC2_RUNTIMES,
         hot_replace=True,

--- a/tasks/util/kata.py
+++ b/tasks/util/kata.py
@@ -18,7 +18,7 @@ from tasks.util.env import (
 from tasks.util.gc import GC_SOURCE_DIR
 from tasks.util.registry import HOST_CERT_PATH
 from tasks.util.versions import KATA_VERSION, PAUSE_IMAGE_VERSION, RUST_VERSION
-from tasks.util.toml import remove_entry_from_toml, update_toml
+from tasks.util.toml import update_toml
 
 KATA_IMAGE_TAG = join(GHCR_URL, GITHUB_ORG, "kata-containers") + f":{KATA_VERSION}"
 
@@ -407,8 +407,7 @@ def replace_agent(
         )
         out = run(pack_cmd, shell=True, env=work_env, capture_output=True)
         assert out.returncode == 0, "Error packing {}: {}".format(
-            package,
-            out.stderr.decode("utf-8")
+            package, out.stderr.decode("utf-8")
         )
         if debug:
             print(out.stdout.decode("utf-8").strip())


### PR DESCRIPTION
We also move SNP to use an oracular-based rootfs, but we stick to using an initrd.